### PR TITLE
Graceful Tomcat shutdown

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,12 +7,33 @@
 	<packaging>war</packaging>
 
 	<name>studio integration war</name>
+	
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		
+		<slf4j.version>1.6.1</slf4j.version>
+		<tomcat.version>7.0.55</tomcat.version>
+	</properties>
 
 	<dependencies>
 		<dependency>
 			<groupId>javax.servlet</groupId>
 			<artifactId>servlet-api</artifactId>
 			<version>2.5</version>
+			<scope>provided</scope>
+		</dependency>
+		<!-- To get Tomcat Server class in order to find Tomcat shutdown port. -->
+		<dependency>
+			<groupId>org.apache.tomcat</groupId>
+			<artifactId>tomcat-catalina</artifactId>
+			<version>${tomcat.version}</version>
+			<scope>provided</scope>
+		</dependency>
+		<!-- To get better login options -->
+		<dependency>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-api</artifactId>
+			<version>${slf4j.version}</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>
@@ -22,6 +43,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-war-plugin</artifactId>
+				<version>2.6</version>
 				<configuration>
 					<webResources>
 						<resource>	
@@ -34,9 +56,10 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.3</version>
 				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
+					<source>1.7</source>
+					<target>1.7</target>
 				</configuration>
 			</plugin>
 		</plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	
 	<groupId>org.bonitasoft.web.tooling</groupId>
 	<artifactId>studio-watchdog</artifactId>
-	<version>6.0.1</version>
+	<version>7.2.0</version>
 	<packaging>war</packaging>
 
 	<name>studio integration war</name>

--- a/src/main/java/org/bonitasoft/console/server/listener/StudioWatchdogListener.java
+++ b/src/main/java/org/bonitasoft/console/server/listener/StudioWatchdogListener.java
@@ -20,6 +20,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.nio.channels.SocketChannel;
+import java.nio.charset.Charset;
 
 import javax.management.MBeanServer;
 import javax.management.MBeanServerFactory;
@@ -146,7 +147,7 @@ public class StudioWatchdogListener implements ServletContextListener {
             // Get the server object
             Server server = (Server) mBeanServer.getAttribute(name, "managedResource");
             
-            // Get adress and port on which we can send the shutdown command
+            // Get address and port on which we can send the shutdown command
             String address = server.getAddress();
             int port = server.getPort();
 
@@ -158,7 +159,7 @@ public class StudioWatchdogListener implements ServletContextListener {
                     Socket clientSocket = new Socket(address, port);
                     OutputStream outputStream = clientSocket.getOutputStream();
             ) {
-                outputStream.write(shutdown.getBytes());
+                outputStream.write(shutdown.getBytes(Charset.forName("UTF-8")));
                 outputStream.flush();
                 outputStream.close();
                 clientSocket.close();

--- a/src/main/java/org/bonitasoft/console/server/listener/StudioWatchdogListener.java
+++ b/src/main/java/org/bonitasoft/console/server/listener/StudioWatchdogListener.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (C) 2009 BonitaSoft S.A.
+ * Copyright (C) 2009-2015 Bonitasoft S.A.
  * BonitaSoft, 32 rue Gustave Eiffel - 38000 Grenoble
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
  * Studio Watchdog Servlet.
  * 
  * @author Julien Mege
+ * @author Antoine Mottier
  */
 public class StudioWatchdogListener implements ServletContextListener {
 
@@ -158,7 +159,8 @@ public class StudioWatchdogListener implements ServletContextListener {
             clientSocket.getOutputStream().close();
             clientSocket.close();
         } catch (Exception e) {
-            LOGGER.error("Error while trying to shutdown Tomcat from watchdog web application", e);
+            LOGGER.error("Error while trying to shutdown Tomcat (using shutdown command) from watchdog web application. We will call now System.exit(-1)", e);
+            System.exit(-1);
         }
    }
 

--- a/src/main/java/org/bonitasoft/console/server/listener/StudioWatchdogListener.java
+++ b/src/main/java/org/bonitasoft/console/server/listener/StudioWatchdogListener.java
@@ -128,38 +128,38 @@ public class StudioWatchdogListener implements ServletContextListener {
 
             }
         }
-        
+
         LOGGER.debug("Bonita Studio JVM is alive");
         return true;
     }
 
     private static void shutdownTomcat() {
-	    try {
-	        // We expect to have only one MBean server. Get it.
-	        MBeanServer mBeanServer = MBeanServerFactory.findMBeanServer(null).get(0);
-	    
-	        // Get Server object name
-    	    ObjectName name = new ObjectName("Catalina", "type", "Server");
-    	    
-    	    // Get the server object
-    	    Server server = (Server) mBeanServer.getAttribute(name, "managedResource");
-    	    
-    	    // Get adress and port on which we can send the shutdown command
-    	    String address = server.getAddress();
-    	    int port = server.getPort();
-    	    
-    	    // Get the shutdown command that we need to send
-    	    String shutdown = server.getShutdown();
-    	    
-    	    // Connect and send the shutdown command    	    
+        try {
+            // We expect to have only one MBean server. Get it.
+            MBeanServer mBeanServer = MBeanServerFactory.findMBeanServer(null).get(0);
+
+            // Get Server object name
+            ObjectName name = new ObjectName("Catalina", "type", "Server");
+
+            // Get the server object
+            Server server = (Server) mBeanServer.getAttribute(name, "managedResource");
+
+            // Get adress and port on which we can send the shutdown command
+            String address = server.getAddress();
+            int port = server.getPort();
+
+            // Get the shutdown command that we need to send
+            String shutdown = server.getShutdown();
+
+            // Connect and send the shutdown command    	    
             Socket clientSocket = new Socket(address, port);
             clientSocket.getOutputStream().write(shutdown.getBytes());
             clientSocket.getOutputStream().flush();
             clientSocket.getOutputStream().close();
             clientSocket.close();
-	    } catch (Exception e) {
-	        LOGGER.error("Error while trying to shutdown Tomcat from watchdog web application", e);
-	    }
+        } catch (Exception e) {
+            LOGGER.error("Error while trying to shutdown Tomcat from watchdog web application", e);
+        }
    }
 
 }


### PR DESCRIPTION
Try to gracefully shutdown the Tomcat by sending a shutdown command insted of using System.exit(-1). This development has been done to fix issue with [h2 and quartz shutdown](https://github.com/bonitasoft/bonita-distrib/pull/14#issuecomment-156434786) but is no longer mandatory to fix the issue.
